### PR TITLE
extending SERVICE_PATTERN #9

### DIFF
--- a/src/main/java/net/straylightlabs/hola/sd/Service.java
+++ b/src/main/java/net/straylightlabs/hola/sd/Service.java
@@ -29,7 +29,7 @@ public class Service {
     private final String name;
     private final List<String> labels;
 
-    private static final Pattern SERVICE_PATTERN = Pattern.compile("^((_[a-zA-Z0-9-]+\\.)?_(tcp|udp))\\.?|$");
+    private static final Pattern SERVICE_PATTERN = Pattern.compile("^((_[a-zA-Z0-9_\\-]+\\.)?_(tcp|udp))\\.?|$");
 
     public static Service fromName(String name) {
         Matcher matcher = SERVICE_PATTERN.matcher(name);

--- a/src/test/java/net/straylightlabs/hola/sd/ServiceTest.java
+++ b/src/test/java/net/straylightlabs/hola/sd/ServiceTest.java
@@ -44,6 +44,10 @@ public class ServiceTest {
         assertTrue("fromName(_my_service._tcp) == _my_service._tcp: " + service.getName(), service.getName().equals("_my_service._tcp"));
         service = Service.fromName("_my_service._tcp.");
         assertTrue("fromName(_my_service._tcp.) == _my_service._tcp: " + service.getName(), service.getName().equals("_my_service._tcp"));
+        service = Service.fromName("_my-service._tcp");
+        assertTrue("fromName(_my-service._tcp) == _my-service._tcp: " + service.getName(), service.getName().equals("_my-service._tcp"));
+        service = Service.fromName("_my-service._tcp.");
+        assertTrue("fromName(_my-service._tcp.) == _my-service._tcp: " + service.getName(), service.getName().equals("_my-service._tcp"));
     }
 
     @Test

--- a/src/test/java/net/straylightlabs/hola/sd/ServiceTest.java
+++ b/src/test/java/net/straylightlabs/hola/sd/ServiceTest.java
@@ -40,6 +40,10 @@ public class ServiceTest {
         assertTrue("fromName(_http._tcp) == _http._tcp: " + service.getName(), service.getName().equals("_http._tcp"));
         service = Service.fromName("_http._tcp.");
         assertTrue("fromName(_http._tcp.) == _http._tcp: " + service.getName(), service.getName().equals("_http._tcp"));
+        service = Service.fromName("_my_service._tcp");
+        assertTrue("fromName(_my_service._tcp) == _my_service._tcp: " + service.getName(), service.getName().equals("_my_service._tcp"));
+        service = Service.fromName("_my_service._tcp.");
+        assertTrue("fromName(_my_service._tcp.) == _my_service._tcp: " + service.getName(), service.getName().equals("_my_service._tcp"));
     }
 
     @Test


### PR DESCRIPTION
This is a fix for #9

This allows `_` to be part of the service name (in the fist group). This makes it that e.g. `_my_service._tcp` can now be recognized by `net.straylightlabs.hola.sd.Service`

This also adds `\` escaping to the `-` in the 1st group of the pattern.